### PR TITLE
Make version attribute a plain String

### DIFF
--- a/lib/bcrypt/password.rb
+++ b/lib/bcrypt/password.rb
@@ -80,7 +80,7 @@ module BCrypt
     # Splits +h+ into version, cost, salt, and hash and returns them in that order.
     def split_hash(h)
       _, v, c, mash = h.split('$')
-      return v, c.to_i, h[0, 29].to_str, mash[-31, 31].to_str
+      return v.to_str, c.to_i, h[0, 29].to_str, mash[-31, 31].to_str
     end
   end
 

--- a/spec/bcrypt/password_spec.rb
+++ b/spec/bcrypt/password_spec.rb
@@ -75,6 +75,7 @@ describe "Reading a hashed password" do
   specify "should read the version, cost, salt, and hash" do
     password = BCrypt::Password.new(@hash)
     expect(password.version).to eql("2a")
+    expect(password.version.class).to eq String
     expect(password.cost).to equal(5)
     expect(password.salt).to eql("$2a$05$CCCCCCCCCCCCCCCCCCCCC.")
     expect(password.salt.class).to eq String


### PR DESCRIPTION
This is a fix for #106. It looks fairly simple so I thought I’d do a quick PR.

When splitting the hash into the components to populate the attributes in `Password` the salt and hash were being converted into plain strings with `to_str`, but the version wasn’t. This was causing problems when trying to use `==` on that attribute (a change to Psych to how strings are serialized to Yaml does this).

This fix just adds a call to `to_str` to the version, to match the salt and hash (the cost is converted with `to_i`) and adds a matching spec.

---

As an aside: This fixes the immediate issue. Dumping a `Password` to Yaml now looks something like this:

```yaml
--- !ruby/string:BCrypt::Password
str: "$2a$10$xbRosG0W6.XkTBSWYDTaVeFTNtWa3uHwudnwLme.KAKkVYMSalqLW"
version: 2a
cost: 10
salt: "$2a$10$xbRosG0W6.XkTBSWYDTaVe"
checksum: FTNtWa3uHwudnwLme.KAKkVYMSalqLW
```

which is what it looked like in Ruby 2.1 (or more accurately with the version of Psych in Ruby 2.1). The version, cost, salt and checksum are all duplicated. Is it worth adding `init_with` and `encode_with` methods to avoid this repetition?