### PR TITLE
Add rake-compiler-dock for building Windows binary gems.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
     rake (10.4.2)
     rake-compiler (0.9.5)
       rake
+    rake-compiler-dock (0.5.1)
     rdoc (3.12.2)
       json (~> 1.4)
     rspec (3.3.0)
@@ -37,6 +38,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt!
   rake-compiler (~> 0.9.2)
+  rake-compiler-dock (~> 0.5.1)
   rdoc (~> 3.12)
   rspec (>= 3)
 

--- a/Rakefile
+++ b/Rakefile
@@ -80,6 +80,14 @@ else
   end
 end
 
+desc "Build the windows binary gems per rake-compiler-dock"
+task 'gem:windows' do
+  require 'rake_compiler_dock'
+  RakeCompilerDock.sh <<-EOT
+    bundle && rake cross native gem
+  EOT
+end
+
 desc "Run a set of benchmarks on the compiled extension."
 task :benchmark do
   TESTS = 100

--- a/Rakefile
+++ b/Rakefile
@@ -8,10 +8,8 @@ require 'benchmark'
 
 CLEAN.include(
   "tmp",
-  "lib/1.8",
-  "lib/1.9",
-  "lib/2.0",
-  "lib/2.1",
+  "lib/1.?",
+  "lib/2.?",
   "lib/bcrypt_ext.jar",
   "lib/bcrypt_ext.so"
 )

--- a/bcrypt.gemspec
+++ b/bcrypt.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_development_dependency 'rake-compiler', '~> 0.9.2'
+  s.add_development_dependency 'rake-compiler-dock', '~> 0.5.1'
   s.add_development_dependency 'rspec', '>= 3'
   s.add_development_dependency 'rdoc', '~> 3.12'
 


### PR DESCRIPTION
[rake-compiler-dock](https://github.com/larskanis/rake-compiler-dock) makes building Windows gems faster and with little to no setup compared to [rake-compiler-dev-box](https://github.com/tjschuck/rake-compiler-dev-box). A simple 'rake gem:windows' is usually enough.

I tested building the fat binary bcrypt gems successfully on Linux and Windows. I also tested all resulting gems on RubyInstaller versions 2.1.4-x64, 2.2.1-x86 and 2.2.1-x64 on Windows-7.

The cross ruby versions used by gem:windows are not passed to the container, so the rake-compiler-dock's defaults are used, which are [defined here](https://github.com/larskanis/rake-compiler-dock/blob/master/Dockerfile#L113).

This fixes #116 .
