### PR TITLE
Appveyor automated CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+version: '{build}'
+
+skip_tags: true
+
+environment:
+  matrix:
+    - ruby_version: "200"
+      devkit: C:\Ruby21\DevKit
+    - ruby_version: "200-x64"
+      devkit: C:\Ruby21-x64\DevKit
+    - ruby_version: "21"
+      devkit: C:\Ruby21\DevKit
+    - ruby_version: "21-x64"
+      devkit: C:\Ruby21-x64\DevKit
+    - ruby_version: "22"
+      devkit: C:\Ruby21\DevKit
+    - ruby_version: "22-x64"
+      devkit: C:\Ruby21-x64\DevKit
+
+install:
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - "%devkit%\\devkitvars.bat"
+  - gem install bundler --no-document
+  - bundler env
+  - bundle install --retry=3
+
+build_script:
+  - bundle exec rake compile
+
+test_script:
+  - bundle exec rake spec


### PR DESCRIPTION
This adds an appveyor.yml. Appveyor is similar to Travis, but runs on a windows host. This will make sure that build problems on windows surface early.

Example output can be seen here: https://ci.appveyor.com/project/ccoenen/bcrypt-ruby/build/5 (one build timeouted in bundler, everything else ran fine).
