### PR TITLE
Fix regex in validator

### DIFF
--- a/lib/bcrypt/engine.rb
+++ b/lib/bcrypt/engine.rb
@@ -80,7 +80,7 @@ module BCrypt
 
     # Returns true if +salt+ is a valid bcrypt() salt, false if not.
     def self.valid_salt?(salt)
-      !!(salt =~ /^\$[0-9a-z]{2,}\$[0-9]{2,}\$[A-Za-z0-9\.\/]{22,}$/)
+      !!(salt =~ /\A\$[0-9a-z]{2,}\$[0-9]{2,}\$[A-Za-z0-9\.\/]{22,}\z/)
     end
 
     # Returns true if +secret+ is a valid bcrypt() secret, false if not.

--- a/lib/bcrypt/password.rb
+++ b/lib/bcrypt/password.rb
@@ -47,7 +47,7 @@ module BCrypt
       end
 
       def valid_hash?(h)
-        /^\$[0-9a-z]{2}\$[0-9]{2}\$[A-Za-z0-9\.\/]{53}$/ === h
+        /\A\$[0-9a-z]{2}\$[0-9]{2}\$[A-Za-z0-9\.\/]{53}\z/ === h
       end
     end
 

--- a/spec/bcrypt/password_spec.rb
+++ b/spec/bcrypt/password_spec.rb
@@ -108,6 +108,7 @@ end
 describe "Validating a generated salt" do
   specify "should not accept an invalid salt" do
     expect(BCrypt::Engine.valid_salt?("invalid")).to eq(false)
+    expect(BCrypt::Engine.valid_salt?("invalid\n#{BCrypt::Engine.generate_salt}\ninvalid")).to eq(false)
   end
   specify "should accept a valid salt" do
     expect(BCrypt::Engine.valid_salt?(BCrypt::Engine.generate_salt)).to eq(true)
@@ -117,6 +118,7 @@ end
 describe "Validating a password hash" do
   specify "should not accept an invalid password" do
     expect(BCrypt::Password.valid_hash?("i_am_so_not_valid")).to be(false)
+    expect(BCrypt::Password.valid_hash?("invalid\n#{BCrypt::Password.create "i_am_so_valid"}\ninvalid")).to be(false)
   end
   specify "should accept a valid password" do
     expect(BCrypt::Password.valid_hash?(BCrypt::Password.create "i_am_so_valid")).to be(true)


### PR DESCRIPTION
``` ruby
valid_salt = BCrypt::Engine.generate_salt
BCrypt::Engine.valid_salt? "invalid\n#{valid_salt}\ninvalid" #=> true, expected: falsey
valid_hash = BCrypt::Password.create 'i_am_so_valid'
BCrypt::Password.valid_hash? "invalid\n#{valid_hash}\ninvalid" #=> 8, expected: falsey
```
