### PR TITLE
unlock the gvl when calculating hashes / salts

### DIFF
--- a/ext/mri/bcrypt_ext.c
+++ b/ext/mri/bcrypt_ext.c
@@ -49,7 +49,7 @@ static VALUE bc_salt(VALUE self, VALUE prefix, VALUE count, VALUE input) {
     if(!salt) return Qnil;
 
     str_salt = rb_str_new2(salt);
-    xfree(salt);
+    free(salt);
 
     return str_salt;
 }
@@ -99,7 +99,7 @@ static VALUE bc_crypt(VALUE self, VALUE key, VALUE setting) {
 
     out = rb_str_new(args.data, args.size - 1);
 
-    xfree(args.data);
+    free(args.data);
 
     return out;
 }

--- a/ext/mri/bcrypt_ext.c
+++ b/ext/mri/bcrypt_ext.c
@@ -5,13 +5,6 @@
 #include <ruby/thread.h>
 #endif
 
-/* Delete this when 1.8 support is dropped. */
-#ifdef HAVE_RB_STR_NEW_FROZEN
-  #define RB_STR_NEW_FROZEN rb_str_new_frozen
-#else
-  #define RB_STR_NEW_FROZEN rb_str_new4
-#endif
-
 static VALUE mBCrypt;
 static VALUE cBCryptEngine;
 
@@ -39,8 +32,8 @@ static VALUE bc_salt(VALUE self, VALUE prefix, VALUE count, VALUE input) {
      * reference to the parameters and mutates them while we are working,
      * that would be very bad.  Duping the strings means that the reference
      * isn't shared. */
-    prefix = RB_STR_NEW_FROZEN(prefix);
-    input  = RB_STR_NEW_FROZEN(input);
+    prefix = rb_str_new_frozen(prefix);
+    input  = rb_str_new_frozen(input);
 
     args.prefix = StringValueCStr(prefix);
     args.count  = NUM2ULONG(count);
@@ -88,8 +81,8 @@ static VALUE bc_crypt(VALUE self, VALUE key, VALUE setting) {
      * reference to the parameters and mutates them while we are working,
      * that would be very bad.  Duping the strings means that the reference
      * isn't shared. */
-    key     = RB_STR_NEW_FROZEN(key);
-    setting = RB_STR_NEW_FROZEN(setting);
+    key     = rb_str_new_frozen(key);
+    setting = rb_str_new_frozen(setting);
 
     args.data    = NULL;
     args.size    = 0xDEADBEEF;

--- a/ext/mri/bcrypt_ext.c
+++ b/ext/mri/bcrypt_ext.c
@@ -1,20 +1,57 @@
 #include <ruby.h>
 #include <ow-crypt.h>
 
+#ifdef HAVE_RUBY_THREAD_H
+#include <ruby/thread.h>
+#endif
+
+/* Delete this when 1.8 support is dropped. */
+#ifdef HAVE_RB_STR_NEW_FROZEN
+  #define RB_STR_NEW_FROZEN rb_str_new_frozen
+#else
+  #define RB_STR_NEW_FROZEN rb_str_new4
+#endif
+
 static VALUE mBCrypt;
 static VALUE cBCryptEngine;
+
+struct bc_salt_args {
+    const char * prefix;
+    unsigned long count;
+    const char * input;
+    int size;
+};
+
+static void * bc_salt_nogvl(void * ptr) {
+    struct bc_salt_args * args = ptr;
+
+    return crypt_gensalt_ra(args->prefix, args->count, args->input, args->size);
+}
 
 /* Given a logarithmic cost parameter, generates a salt for use with +bc_crypt+.
 */
 static VALUE bc_salt(VALUE self, VALUE prefix, VALUE count, VALUE input) {
     char * salt;
     VALUE str_salt;
+    struct bc_salt_args args;
 
-    salt = crypt_gensalt_ra(
-	    StringValuePtr(prefix),
-	    NUM2ULONG(count),
-	    NIL_P(input) ? NULL : StringValuePtr(input),
-	    NIL_P(input) ? 0 : RSTRING_LEN(input));
+    /* duplicate the parameters for thread safety.  If another thread has a
+     * reference to the parameters and mutates them while we are working,
+     * that would be very bad.  Duping the strings means that the reference
+     * isn't shared. */
+    prefix = RB_STR_NEW_FROZEN(prefix);
+    input  = RB_STR_NEW_FROZEN(input);
+
+    args.prefix = StringValuePtr(prefix);
+    args.count  = NUM2ULONG(count);
+    args.input  = NIL_P(input) ? NULL : StringValuePtr(input);
+    args.size   = NIL_P(input) ? 0 : RSTRING_LEN(input);
+
+#ifdef HAVE_RUBY_THREAD_H
+    salt = rb_thread_call_without_gvl(bc_salt_nogvl, &args, NULL, NULL);
+#else
+    salt = bc_salt_nogvl((void *)&args);
+#endif
 
     if(!salt) return Qnil;
 
@@ -24,30 +61,52 @@ static VALUE bc_salt(VALUE self, VALUE prefix, VALUE count, VALUE input) {
     return str_salt;
 }
 
+struct bc_crypt_args {
+    const char * key;
+    const char * setting;
+    void * data;
+    int size;
+};
+
+static void * bc_crypt_nogvl(void * ptr) {
+    struct bc_crypt_args * args = ptr;
+
+    return crypt_ra(args->key, args->setting, &args->data, &args->size);
+}
+
 /* Given a secret and a salt, generates a salted hash (which you can then store safely).
 */
 static VALUE bc_crypt(VALUE self, VALUE key, VALUE setting) {
     char * value;
-    void * data;
-    int size;
     VALUE out;
 
-    data = NULL;
-    size = 0xDEADBEEF;
+    struct bc_crypt_args args;
 
     if(NIL_P(key) || NIL_P(setting)) return Qnil;
 
-    value = crypt_ra(
-	    NIL_P(key) ? NULL : StringValuePtr(key),
-	    NIL_P(setting) ? NULL : StringValuePtr(setting),
-	    &data,
-	    &size);
+    /* duplicate the parameters for thread safety.  If another thread has a
+     * reference to the parameters and mutates them while we are working,
+     * that would be very bad.  Duping the strings means that the reference
+     * isn't shared. */
+    key     = RB_STR_NEW_FROZEN(key);
+    setting = RB_STR_NEW_FROZEN(setting);
+
+    args.data    = NULL;
+    args.size    = 0xDEADBEEF;
+    args.key     = NIL_P(key)     ? NULL : StringValuePtr(key);
+    args.setting = NIL_P(setting) ? NULL : StringValuePtr(setting);
+
+#ifdef HAVE_RUBY_THREAD_H
+    value = rb_thread_call_without_gvl(bc_crypt_nogvl, &args, NULL, NULL);
+#else
+    value = bc_crypt_nogvl((void *)&args);
+#endif
 
     if(!value) return Qnil;
 
-    out = rb_str_new2(value);
+    out = rb_str_new(args.data, args.size - 1);
 
-    xfree(data);
+    xfree(args.data);
 
     return out;
 }

--- a/ext/mri/bcrypt_ext.c
+++ b/ext/mri/bcrypt_ext.c
@@ -42,7 +42,7 @@ static VALUE bc_salt(VALUE self, VALUE prefix, VALUE count, VALUE input) {
     prefix = RB_STR_NEW_FROZEN(prefix);
     input  = RB_STR_NEW_FROZEN(input);
 
-    args.prefix = StringValuePtr(prefix);
+    args.prefix = StringValueCStr(prefix);
     args.count  = NUM2ULONG(count);
     args.input  = NIL_P(input) ? NULL : StringValuePtr(input);
     args.size   = NIL_P(input) ? 0 : RSTRING_LEN(input);
@@ -93,8 +93,8 @@ static VALUE bc_crypt(VALUE self, VALUE key, VALUE setting) {
 
     args.data    = NULL;
     args.size    = 0xDEADBEEF;
-    args.key     = NIL_P(key)     ? NULL : StringValuePtr(key);
-    args.setting = NIL_P(setting) ? NULL : StringValuePtr(setting);
+    args.key     = NIL_P(key)     ? NULL : StringValueCStr(key);
+    args.setting = NIL_P(setting) ? NULL : StringValueCStr(setting);
 
 #ifdef HAVE_RUBY_THREAD_H
     value = rb_thread_call_without_gvl(bc_crypt_nogvl, &args, NULL, NULL);
@@ -102,7 +102,7 @@ static VALUE bc_crypt(VALUE self, VALUE key, VALUE setting) {
     value = bc_crypt_nogvl((void *)&args);
 #endif
 
-    if(!value) return Qnil;
+    if(!value || !args.data) return Qnil;
 
     out = rb_str_new(args.data, args.size - 1);
 

--- a/ext/mri/extconf.rb
+++ b/ext/mri/extconf.rb
@@ -18,5 +18,6 @@ else
 
   $defs << "-D__SKIP_GNU"
   dir_config("bcrypt_ext")
+  have_func 'rb_str_new_frozen' # Ruby 1.8 support.
   create_makefile("bcrypt_ext")
 end

--- a/ext/mri/extconf.rb
+++ b/ext/mri/extconf.rb
@@ -18,6 +18,5 @@ else
 
   $defs << "-D__SKIP_GNU"
   dir_config("bcrypt_ext")
-  have_func 'rb_str_new_frozen' # Ruby 1.8 support.
   create_makefile("bcrypt_ext")
 end


### PR DESCRIPTION
Holding on to the GVL means we can't do anything in parallel.  Since
these are CPU-only operations that do not involve the ruby interpreter,
we can safely unlock the GVL when calculating hashes.

This program demonstrates the difference:

``` ruby
require 'bcrypt'
require 'thread'

GUESSES = (ENV['GUESSES'] || 100).to_i
THREADS = (ENV['THREADS'] || 1).to_i

p GUESSES: GUESSES, THREADS: THREADS

password = BCrypt::Password.create 'hello world!'

queue = Queue.new
GUESSES.times { queue << "x" * 90 }
THREADS.times { queue << nil }
THREADS.times.map {
  Thread.new {
    while guess = queue.pop
      password == guess
    end
  }
}.each(&:join)
```

Without this patch:

```
[aaron@TC bcrypt-ruby (master)]$ time THREADS=4 ruby test.rb
{:GUESSES=>100, :THREADS=>4}

real    0m30.014s
user    0m29.739s
sys 0m0.153s
```

With the patch:

```
[aaron@TC bcrypt-ruby (master)]$ time THREADS=4 ruby -Ilib test.rb
{:GUESSES=>100, :THREADS=>4}

real    0m12.293s
user    0m42.382s
sys 0m0.169s
```

If you run this program with the patch, you can see Ruby use nearly 400% CPU,
as long as you have a 4 core machine.

Sending this as a PR because I'm not sure if the feature detection is enough to work on all versions of Ruby we support and I figured I'd let the CI test it.  If something fails, I'll add better feature detection.
