### PR TITLE
Remove Rails forgot password example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,6 @@ implements a similar authentication strategy to the code below.
       end
     end
 
-### If a user forgets their password?
-
-    # assign them a random one and mail it to them, asking them to change it
-    def forgot_password
-      @user = User.find_by_email(params[:email])
-      random_password = Array.new(10).map { (65 + rand(58)).chr }.join
-      @user.password = random_password
-      @user.save!
-      Mailer.create_and_deliver_password_change(@user, random_password)
-    end
-
 ## How to use bcrypt-ruby in general
 
     require 'bcrypt'


### PR DESCRIPTION
The forgot password feature is out of scope of this gem and not a very
good example on itself.  Sending plain text passwords by email is
considered unsecure because SMTP, IMAP and POP and often used
unencrypted.