### PR TITLE
Use the same parameter types as what's defined by GNU crypt_r()

### DIFF
--- a/ext/mri/ow-crypt.h
+++ b/ext/mri/ow-crypt.h
@@ -16,7 +16,7 @@
 
 #ifndef __SKIP_GNU
 extern char *crypt(__CONST char *key, __CONST char *setting);
-extern char *crypt_r(__CONST char *key, __CONST char *setting, void *data);
+extern char *crypt_r(__CONST char *key, __CONST char *setting, struct crypt_data *data);
 #endif
 
 #ifndef __SKIP_OW

--- a/ext/mri/wrapper.c
+++ b/ext/mri/wrapper.c
@@ -185,7 +185,7 @@ char *crypt_ra(__CONST char *key, __CONST char *setting,
 	return _crypt_blowfish_rn(key, setting, (char *)*data, *size);
 }
 
-char *crypt_r(__CONST char *key, __CONST char *setting, void *data)
+char *crypt_r(__CONST char *key, __CONST char *setting, struct crypt_data *data)
 {
 	return _crypt_retval_magic(
 		crypt_rn(key, setting, data, CRYPT_OUTPUT_SIZE),


### PR DESCRIPTION
On a TrueOS-Desktop (devel release, based on FreeBSD 12-current) installation, it seems that building bcrypt-ruby would generate an error regarding the crypt_r function:
```
./ow-crypt.h:19:14: error: conflicting types for 'crypt_r'
extern char *crypt_r(__CONST char *key, __CONST char *setting, void *data);
             ^
/usr/include/unistd.h:497:7: note: previous declaration is here
char    *crypt_r(const char *, const char *, struct crypt_data *);
```

The official GNU [crypt_r](http://man7.org/linux/man-pages/man3/crypt.3.html) implementation defines the 3rd parameter as `struct crypt_data *` as well.  The same function appears in FreeBSD, which is my target platform.