### PR TITLE
Add Ruby 2.4 to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+before_install:
+  # jruby-head does not have bundler.
+  - which bundle || gem install bundler
 rvm:
   - 1.8.7
   - 1.9.2
@@ -7,10 +10,15 @@ rvm:
   - 2.1.0
   - 2.2.0
   - 2.3.0
+  - 2.4.1
   - ruby-head
   - jruby-18mode
   - jruby-19mode
   - jruby-head
-  - rbx-2
+  - rbx
   - ree
 script: bundle exec rake
+matrix:
+  allow_failures:
+    - rvm: rbx
+  fast_finish: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    json (1.8.3)
-    json (1.8.3-java)
+    diff-lcs (1.3)
+    json (1.8.6)
+    json (1.8.6-java)
     rake (10.4.2)
     rake-compiler (0.9.5)
       rake


### PR DESCRIPTION
Hi I prepared the PR to add Ruby 2.4 to Travis CI.
I also updated `json` to 1.8.6 for Ruby 2.4 compatibility to fix below issue.

```
$ ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]

$ bundle install --path vendor/bundle
...
compiling generator.c
generator.c: In function ‘generate_json’:
generator.c:861:25: error: ‘rb_cFixnum’ undeclared (first use in this function)
     } else if (klass == rb_cFixnum) {
                         ^~~~~~~~~~
generator.c:861:25: note: each undeclared identifier is reported only once for each
function it appears in
generator.c:863:25: error: ‘rb_cBignum’ undeclared (first use in this function)
     } else if (klass == rb_cBignum) {
                         ^~~~~~~~~~
generator.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-self-assign’
cc1: warning: unrecognized command line option ‘-Wno-constant-logical-operand’
cc1: warning: unrecognized command line option ‘-Wno-parentheses-equality’
Makefile:241: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1
```

Is it possible?
Thanks.