### PR TITLE
bcrypt_ext: Add compatibility with libxcrypt

### DIFF
--- a/ext/mri/bcrypt_ext.c
+++ b/ext/mri/bcrypt_ext.c
@@ -45,7 +45,7 @@ static VALUE bc_crypt(VALUE self, VALUE key, VALUE setting) {
 
     if(!value) return Qnil;
 
-    out = rb_str_new(data, size - 1);
+    out = rb_str_new2(value);
 
     xfree(data);
 


### PR DESCRIPTION
The return values of `crypt()` and `crypt_gensalt()` should be treated as real c-strings instead of binary data by the module.