### PR TITLE
Use AppVeyor for testing Windows gem installs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,50 @@
+###############################################################################
+#
+# This AppVeyor config is *NOT* for running the tests on Windows.
+#
+# This is to ensure that the latest version of the bcrypt gem can be installed
+# on Windows across all of the currently supported versions of Ruby.
+#
+###############################################################################
+
+version: "{branch}-{build}"
+build: off
+clone_depth: 1
+
+init:
+  # Install Ruby 1.8.7
+  - if %RUBY_VERSION%==187 (
+      appveyor DownloadFile https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-1.8.7-p374.exe -FileName C:\ruby_187.exe &
+      C:\ruby_187.exe /verysilent /dir=C:\Ruby%RUBY_VERSION%
+    )
+
+environment:
+  matrix:
+    - RUBY_VERSION: "187"
+    - RUBY_VERSION: "193"
+    - RUBY_VERSION: "200"
+    - RUBY_VERSION: "200-x64"
+    - RUBY_VERSION: "21"
+    - RUBY_VERSION: "21-x64"
+    - RUBY_VERSION: "22"
+    - RUBY_VERSION: "22-x64"
+    - RUBY_VERSION: "23"
+    - RUBY_VERSION: "23-x64"
+    - RUBY_VERSION: "24"
+    - RUBY_VERSION: "24-x64"
+    - RUBY_VERSION: "25"
+    - RUBY_VERSION: "25-x64"
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - if %RUBY_VERSION%==187 (
+      gem update --system 2.0.17
+    )
+
+before_test:
+  - ruby -v
+  - gem -v
+
+test_script:
+  - gem install bcrypt --prerelease --no-ri --no-rdoc
+  - ruby -e "require 'rubygems'; require 'bcrypt'"


### PR DESCRIPTION
Notably, this is _not_ using AppVeyor for running the tests like you'd typically expect from CI.

Our big issue with Windows historically isn't running the tests, it's actually installing the gem.  This just leverages AppVeyor's infrastructure to let us try to install the bcrypt gem on Windows across all versions of Ruby that we intend to support.

See:

- https://github.com/codahale/bcrypt-ruby/issues/139
- https://github.com/codahale/bcrypt-ruby/issues/141
- https://github.com/codahale/bcrypt-ruby/issues/142
- https://github.com/codahale/bcrypt-ruby/issues/149
- ...plus countless others 😓

This doesn't actually fix the issue (that comes from me repackaging the gem and pushing the versions with new binaries), but it _does_ give us an indication that it's working.  I made this intentionally work with "prerelease" versions of the gem, so I can push up `.rc` versions to test without fully pushing out (possibly still broken) new versions.

See https://ci.appveyor.com/project/TJSchuck35975/bcrypt-ruby/build/windows_ci-19 for the example output — as you can see, this is "correctly" failing for Ruby 2.3+, and passing for everything below.

Note also that this is just installing the latest version of the gem _currently pushed to RubyGems.org_, and has pretty much nothing to actually do with this repo — using GitHub webhooks is just the easiest way to get it to automatically build.  I can also manually kick off builds from the AppVeyor web UI as needed.

/cc @tenderlove 