### PR TITLE
RC for 3.1.12 release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,3 +82,7 @@
 
 3.1.11 Mar 06 2016
   - Add support for Ruby 2.2 in compiled Windows binaries
+
+3.1.12 May 15 2018
+  - Add support for Ruby 2.3, 2.4, and 2.5 in compiled Windows binaries
+  - Fix compatibility with libxcrypt [GH #164 by @besser82]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -83,6 +83,6 @@
 3.1.11 Mar 06 2016
   - Add support for Ruby 2.2 in compiled Windows binaries
 
-3.1.12 May 15 2018
+3.1.12 May 16 2018
   - Add support for Ruby 2.3, 2.4, and 2.5 in compiled Windows binaries
   - Fix compatibility with libxcrypt [GH #164 by @besser82]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bcrypt (3.1.12.rc1)
+    bcrypt (3.1.12)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bcrypt (3.1.11)
+    bcrypt (3.1.12.rc1)
 
 GEM
   remote: https://rubygems.org/
@@ -41,4 +41,4 @@ DEPENDENCIES
   rspec (>= 3)
 
 BUNDLED WITH
-   1.11.2
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ re-hash those passwords. This vulnerability only affected the JRuby gem.
 The bcrypt gem is available on the following ruby platforms:
 
 * JRuby
-* RubyInstaller 1.8, 1.9, 2.0, 2.1, and 2.2 builds on win32
-* Any 1.8, 1.9, 2.0, 2.1, 2.2, or 2.3 Ruby on a BSD/OS X/Linux system with a compiler
+* RubyInstaller 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, and 2.5 builds on Windows
+* Any 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, or 2.5 Ruby on a BSD/OS X/Linux system with a compiler
 
 ## How to use `bcrypt()` in your Rails application
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,10 @@ CLEAN.include(
   "lib/1.9",
   "lib/2.0",
   "lib/2.1",
+  "lib/2.2",
+  "lib/2.3",
+  "lib/2.4",
+  "lib/2.5",
   "lib/bcrypt_ext.jar",
   "lib/bcrypt_ext.so"
 )

--- a/bcrypt.gemspec
+++ b/bcrypt.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'bcrypt'
-  s.version = '3.1.12.rc1'
+  s.version = '3.1.12'
 
   s.summary = "OpenBSD's bcrypt() password hashing algorithm."
   s.description = <<-EOF

--- a/bcrypt.gemspec
+++ b/bcrypt.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'bcrypt'
-  s.version = '3.1.11'
+  s.version = '3.1.12.rc1'
 
   s.summary = "OpenBSD's bcrypt() password hashing algorithm."
   s.description = <<-EOF


### PR DESCRIPTION
With support for 2.3-2.5 on Windows and Fedora 28 with libxcrypt.

I have pushed 3.1.12.rc1 to RubyGems.org: https://rubygems.org/gems/bcrypt/versions

AppVeyor should install all the Windows versions successfully now; see #171.

This version should also work on Fedora 28 with libxcrypt; see #164.

/cc @tenderlove 