### PR TITLE
No more Windows fat binaries (or precompiled binaries at all)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,3 +86,6 @@
 3.1.12 May 16 2018
   - Add support for Ruby 2.3, 2.4, and 2.5 in compiled Windows binaries
   - Fix compatibility with libxcrypt [GH #164 by @besser82]
+
+[DRAFT] 4.0.0 MMM DD YYYY
+  - No longer include compiled binaries for Windows. See GH #173.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,8 +31,6 @@ GEM
 PLATFORMS
   java
   ruby
-  x64-mingw32
-  x86-mingw32
 
 DEPENDENCIES
   bcrypt!

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ re-hash those passwords. This vulnerability only affected the JRuby gem.
 
     gem install bcrypt
 
-The bcrypt gem is available on the following ruby platforms:
+The bcrypt gem is available on the following Ruby platforms:
 
 * JRuby
-* RubyInstaller 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, and 2.5 builds on Windows
-* Any 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, or 2.5 Ruby on a BSD/OS X/Linux system with a compiler
+* RubyInstaller 1.8 – 2.5 builds on Windows with the DevKit
+* Any 1.8 – 2.5 Ruby on a BSD/OS X/Linux system with a compiler
 
 ## How to use `bcrypt()` in your Rails application
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,14 +8,6 @@ require 'benchmark'
 
 CLEAN.include(
   "tmp",
-  "lib/1.8",
-  "lib/1.9",
-  "lib/2.0",
-  "lib/2.1",
-  "lib/2.2",
-  "lib/2.3",
-  "lib/2.4",
-  "lib/2.5",
   "lib/bcrypt_ext.jar",
   "lib/bcrypt_ext.so"
 )
@@ -62,25 +54,6 @@ if RUBY_PLATFORM =~ /java/
 else
   Rake::ExtensionTask.new("bcrypt_ext", GEMSPEC) do |ext|
     ext.ext_dir = 'ext/mri'
-    ext.cross_compile = true
-    ext.cross_platform = ['x86-mingw32', 'x64-mingw32']
-  end
-
-  ENV['RUBY_CC_VERSION'].to_s.split(':').each do |ruby_version|
-    platforms = {
-      "x86-mingw32" => "i686-w64-mingw32",
-      "x64-mingw32" => "x86_64-w64-mingw32"
-    }
-    platforms.each do |platform, prefix|
-      task "copy:bcrypt_ext:#{platform}:#{ruby_version}" do |t|
-        %w[lib tmp/#{platform}/stage/lib].each do |dir|
-          so_file = "#{dir}/#{ruby_version[/^\d+\.\d+/]}/bcrypt_ext.so"
-          if File.exists?(so_file)
-            sh "#{prefix}-strip -S #{so_file}"
-          end
-        end
-      end
-    end
   end
 end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,3 @@
-###############################################################################
-#
-# This AppVeyor config is *NOT* for running the tests on Windows.
-#
-# This is to ensure that the latest version of the bcrypt gem can be installed
-# on Windows across all of the currently supported versions of Ruby.
-#
-###############################################################################
-
 version: "{branch}-{build}"
 build: off
 clone_depth: 1
@@ -18,33 +9,64 @@ init:
       C:\ruby_187.exe /verysilent /dir=C:\Ruby%RUBY_VERSION%
     )
 
+  # Install Ruby head
+  - if %RUBY_VERSION%==head (
+      appveyor DownloadFile https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x86.exe -FileName C:\head_x86.exe &
+      C:\head_x86.exe /verysilent /dir=C:\Ruby%RUBY_VERSION%
+    )
+  - if %RUBY_VERSION%==head-x64 (
+      appveyor DownloadFile https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x64.exe -FileName C:\head_x64.exe &
+      C:\head_x64.exe /verysilent /dir=C:\Ruby%RUBY_VERSION%
+    )
+
+  # Add Ruby to the path
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+
+  # Install DevKit 4.5.2 for Ruby 1.8.7
+  - if %RUBY_VERSION%==187 (
+      mkdir C:\DevKit452 &
+      appveyor DownloadFile https://dl.bintray.com/oneclick/rubyinstaller/defunct/DevKit-tdm-32-4.5.2-20110712-1620-sfx.exe -FileName C:\DevKit452\devkit_452.exe &
+      cd C:\DevKit452 &
+      7z x devkit_452.exe &
+      ruby dk.rb init &
+      ruby dk.rb install &
+      cd C:\projects\bcrypt-ruby
+    )
+
 environment:
   matrix:
-    - RUBY_VERSION: "187"
-    - RUBY_VERSION: "193"
-    - RUBY_VERSION: "200"
-    - RUBY_VERSION: "200-x64"
-    - RUBY_VERSION: "21"
-    - RUBY_VERSION: "21-x64"
-    - RUBY_VERSION: "22"
-    - RUBY_VERSION: "22-x64"
-    - RUBY_VERSION: "23"
-    - RUBY_VERSION: "23-x64"
-    - RUBY_VERSION: "24"
-    - RUBY_VERSION: "24-x64"
+    - RUBY_VERSION: "head"
+    - RUBY_VERSION: "head-x64"
     - RUBY_VERSION: "25"
     - RUBY_VERSION: "25-x64"
+    - RUBY_VERSION: "24"
+    - RUBY_VERSION: "24-x64"
+    - RUBY_VERSION: "23"
+    - RUBY_VERSION: "23-x64"
+    - RUBY_VERSION: "22"
+    - RUBY_VERSION: "22-x64"
+    - RUBY_VERSION: "21"
+    - RUBY_VERSION: "21-x64"
+    - RUBY_VERSION: "200"
+    - RUBY_VERSION: "200-x64"
+    - RUBY_VERSION: "193"
+    - RUBY_VERSION: "187"
 
 install:
-  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
   - if %RUBY_VERSION%==187 (
-      gem update --system 2.0.17
+      gem update --system 2.0.17 &
+      C:\DevKit452\devkitvars.bat
     )
+  - if %RUBY_VERSION%==head     ( gem install bundler )
+  - if %RUBY_VERSION%==head-x64 ( gem install bundler )
+  - bundle install
 
 before_test:
   - ruby -v
   - gem -v
 
+build_script:
+  - bundle exec rake compile -rdevkit
+
 test_script:
-  - gem install bcrypt --prerelease --no-ri --no-rdoc
-  - ruby -e "require 'rubygems'; require 'bcrypt'"
+  - bundle exec rake spec

--- a/lib/bcrypt.rb
+++ b/lib/bcrypt.rb
@@ -9,12 +9,7 @@ else
   require "openssl"
 end
 
-begin
-  RUBY_VERSION =~ /(\d+.\d+)/
-  require "#{$1}/bcrypt_ext"
-rescue LoadError
-  require "bcrypt_ext"
-end
+require "bcrypt_ext"
 
 require 'bcrypt/error'
 require 'bcrypt/engine'


### PR DESCRIPTION
@tenderlove @larskanis Fixes #173.

We will now no longer provide compiled binaries at all, and particularly not Windows fat binaries.  The AppVeyor config has been updated to now actually compile the lib and run the tests, not just install the gem like we were previously testing.