### PR TITLE
Appveyor - Create fat-binary gems and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@ tmp
 *.jar
 .DS_Store
 .rbenv-gemsets
+
+# windows build artifacts
+/win_gem_test/shared/
+/win_gem_test/packages/
+/win_gem_test/test_logs/
+/Rakefile_wintest
+*.gem
+/lib/puma/puma_http11.rb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,50 +1,20 @@
-###############################################################################
-#
-# This AppVeyor config is *NOT* for running the tests on Windows.
-#
-# This is to ensure that the latest version of the bcrypt gem can be installed
-# on Windows across all of the currently supported versions of Ruby.
-#
-###############################################################################
+install:
+  # download shared script files
+  - ps: >-
+      if ( !(Test-Path -Path ./shared -PathType Container) ) {
+        $uri = 'https://ci.appveyor.com/api/projects/MSP-Greg/av-gem-build-test/artifacts/shared.7z'
+        $7z  = 'C:\Program Files\7-Zip\7z.exe'
+        $fn = "$env:TEMP\shared.7z"
+        (New-Object System.Net.WebClient).DownloadFile($uri, $fn)
+        &$7z x $fn -owin_gem_test 1> $null
+        Remove-Item  -LiteralPath $fn -Force
+        Write-Host "Downloaded shared files" -ForegroundColor Yellow
+      }
 
-version: "{branch}-{build}"
-build: off
-clone_depth: 1
-
-init:
-  # Install Ruby 1.8.7
-  - if %RUBY_VERSION%==187 (
-      appveyor DownloadFile https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-1.8.7-p374.exe -FileName C:\ruby_187.exe &
-      C:\ruby_187.exe /verysilent /dir=C:\Ruby%RUBY_VERSION%
-    )
+build_script:
+  - ps: .\win_gem_test\bcrypt.ps1 $env:gem_bits
 
 environment:
   matrix:
-    - RUBY_VERSION: "187"
-    - RUBY_VERSION: "193"
-    - RUBY_VERSION: "200"
-    - RUBY_VERSION: "200-x64"
-    - RUBY_VERSION: "21"
-    - RUBY_VERSION: "21-x64"
-    - RUBY_VERSION: "22"
-    - RUBY_VERSION: "22-x64"
-    - RUBY_VERSION: "23"
-    - RUBY_VERSION: "23-x64"
-    - RUBY_VERSION: "24"
-    - RUBY_VERSION: "24-x64"
-    - RUBY_VERSION: "25"
-    - RUBY_VERSION: "25-x64"
-
-install:
-  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
-  - if %RUBY_VERSION%==187 (
-      gem update --system 2.0.17
-    )
-
-before_test:
-  - ruby -v
-  - gem -v
-
-test_script:
-  - gem install bcrypt --prerelease --no-ri --no-rdoc
-  - ruby -e "require 'rubygems'; require 'bcrypt'"
+    - gem_bits: 64
+    - gem_bits: 32

--- a/win_gem_test/Rakefile_wintest
+++ b/win_gem_test/Rakefile_wintest
@@ -1,0 +1,12 @@
+# rake -f Rakefile_wintest -N -R norakelib
+
+require "rake/testtask"
+require 'rspec/core/rake_task'
+
+desc "Run all specs in Windows"
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = 'spec/**/*_spec.rb'
+  t.ruby_opts = '-w'
+end
+
+task :default => [:spec]

--- a/win_gem_test/bcrypt.ps1
+++ b/win_gem_test/bcrypt.ps1
@@ -1,0 +1,42 @@
+# PowerShell script for building & testing SQLite3-Ruby fat binary gem
+# Code by MSP-Greg, see https://github.com/MSP-Greg/av-gem-build-test
+
+# load utility functions, pass 64 or 32
+. $PSScriptRoot\shared\appveyor_setup.ps1 $args[0]
+if ($LastExitCode) { exit }
+
+# above is required code
+#———————————————————————————————————————————————————————————————— above for all repos
+
+Make-Const gem_name  'bcrypt'
+Make-Const repo_name 'bcrypt-ruby'
+Make-Const url_repo  'https://github.com/codahale/bcrypt-ruby.git'
+
+#———————————————————————————————————————————————————————————————— lowest ruby version
+Make-Const ruby_vers_low 20
+
+#———————————————————————————————————————————————————————————————— make info
+Make-Const dest_so   'lib'
+Make-Const exts      @(
+  @{ 'conf' = 'ext/mri/extconf.rb' ; 'so' = 'bcrypt_ext' }
+)
+Make-Const write_so_require $false
+
+#———————————————————————————————————————————————————————————————— Run-Tests
+function Run-Tests {
+  # call with comma separated list of gems to install or update
+  Update-Gems rspec, rake
+  rake -f Rakefile_wintest -N -R norakelib | Set-Content -Path $log_name -PassThru -Encoding UTF8
+  rspec_summary
+}
+
+#———————————————————————————————————————————————————————————————— below for all repos
+# below is required code
+Make-Const dir_gem  $(Convert-Path $PSScriptRoot\..)
+Make-Const dir_ps   $PSScriptRoot
+
+Push-Location $PSScriptRoot
+.\shared\make.ps1
+.\shared\test.ps1
+Pop-Location
+exit $ttl_errors_fails + $exit_code

--- a/win_gem_test/package_gem.rb
+++ b/win_gem_test/package_gem.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'rubygems/package'
+
+spec = Gem::Specification.load("./bcrypt.gemspec")
+
+spec.files.concat ['Rakefile_wintest']
+spec.files.concat Dir['lib/**/*.so']
+spec.test_files = Dir['spec/**/*_spec.rb']
+
+# below lines are required and not gem specific
+spec.platform = ARGV[0]
+spec.required_ruby_version = [">= #{ARGV[1]}", "< #{ARGV[2]}"]
+spec.extensions = []
+if spec.respond_to?(:metadata=)
+  spec.metadata.delete("msys2_mingw_dependencies")
+  spec.metadata['commit'] = ENV['commit_info']
+end
+
+Gem::Package.build(spec)


### PR DESCRIPTION
Two jobs on Appveyor, 64 bit & 32 bit

1. Builds Windows fat binary gems - currently for 2.0 thru 2.5.  64 bit also includes trunk.
2. Loops thru all Ruby versions, installs the gem, and tests.
3. Tests are shown on the Appveyor job test tab.
4. A run on my fork took 5:16.
5. Gems and a 7z of test logs are saved as artifacts
6. Current commit info (date, short SHA, summary) is stored in gemspec as metadata.