### PR TITLE
Bump default cost to 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ end
 require 'bcrypt'
 
 my_password = BCrypt::Password.create("my password")
-#=> "$2a$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa"
+#=> "$2a$12$K0ByB.6YI2/OYrB4fQOYLe6Tv0datUVf6VZ/2Jzwm879BW5K1cHey"
 
 my_password.version              #=> "2a"
-my_password.cost                 #=> 10
+my_password.cost                 #=> 12
 my_password == "my password"     #=> true
 my_password == "not my password" #=> false
 
-my_password = BCrypt::Password.new("$2a$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa")
+my_password = BCrypt::Password.new("$2a$12$K0ByB.6YI2/OYrB4fQOYLe6Tv0datUVf6VZ/2Jzwm879BW5K1cHey")
 my_password == "my password"     #=> true
 my_password == "not my password" #=> false
 ```
@@ -155,14 +155,14 @@ If an attacker was using Ruby to check each password, they could check ~140,000 
 In addition, `bcrypt()` allows you to increase the amount of work required to hash a password as computers get faster. Old
 passwords will still work fine, but new passwords can keep up with the times.
 
-The default cost factor used by bcrypt-ruby is 10, which is fine for session-based authentication. If you are using a
+The default cost factor used by bcrypt-ruby is 12, which is fine for session-based authentication. If you are using a
 stateless authentication architecture (e.g., HTTP Basic Auth), you will want to lower the cost factor to reduce your
 server load and keep your request times down. This will lower the security provided you, but there are few alternatives.
 
 To change the default cost factor used by bcrypt-ruby, use `BCrypt::Engine.cost = new_value`:
 ```ruby
 BCrypt::Password.create('secret').cost
-  #=> 10, the default provided by bcrypt-ruby
+  #=> 12, the default provided by bcrypt-ruby
 
 # set a new default cost
 BCrypt::Engine.cost = 8

--- a/lib/bcrypt/engine.rb
+++ b/lib/bcrypt/engine.rb
@@ -2,7 +2,7 @@ module BCrypt
   # A Ruby wrapper for the bcrypt() C extension calls and the Java calls.
   class Engine
     # The default computational expense parameter.
-    DEFAULT_COST    = 10
+    DEFAULT_COST    = 12
     # The minimum cost supported by the algorithm.
     MIN_COST        = 4
     # Maximum possible size of bcrypt() salts.
@@ -28,8 +28,8 @@ module BCrypt
     #
     # Example:
     #
-    #   BCrypt::Engine::DEFAULT_COST            #=> 10
-    #   BCrypt::Password.create('secret').cost  #=> 10
+    #   BCrypt::Engine::DEFAULT_COST            #=> 12
+    #   BCrypt::Password.create('secret').cost  #=> 12
     #
     #   BCrypt::Engine.cost = 8
     #   BCrypt::Password.create('secret').cost  #=> 8

--- a/lib/bcrypt/password.rb
+++ b/lib/bcrypt/password.rb
@@ -7,7 +7,7 @@ module BCrypt
   #
   #   # hash a user's password
   #   @password = Password.create("my grand secret")
-  #   @password #=> "$2a$10$GtKs1Kbsig8ULHZzO1h2TetZfhO4Fmlxphp8bVKnUlZCBYYClPohG"
+  #   @password #=> "$2a$12$C5.FIvVDS9W4AYZ/Ib37YuWd/7ozp1UaMhU28UKrfSxp2oDchbi3K"
   #
   #   # store it safely
   #   @user.update_attribute(:password, @password)


### PR DESCRIPTION
The default cost has not changed since the [initial checkin](https://github.com/codahale/bcrypt-ruby/commit/a548e49bf23003f0da89137eecb2a2d0779da38a#diff-0ea0d19ec56e9e4c11d0a511b401ee25R18) of the code in 2007. Computers have gotten faster in general and GPGPU password cracking became a thing.

`BCrypt::Engine.calibrate(250)` returns 12 on my Intel Core i7-4870HQ (mid-2015 Macbook). Some people [argued in 2015 already](https://security.stackexchange.com/a/83382/24849) that this should be the default so I think this is a pretty safe value to go with without too much bikeshedding.