### PR TITLE
Remove explicit support for Rubies 1.8 and 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ before_install:
   - gem update --system
   - gem install bundler
 rvm:
-  - 1.8
-  - 1.9
   - 2.0
   - 2.1
   - 2.2
@@ -14,8 +12,6 @@ rvm:
   - 2.5
   - 2.6
   - ruby-head
-  - jruby-18mode
-  - jruby-19mode
   - jruby-head
   - rbx-3
   - ree

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -91,3 +91,4 @@
   - No longer include compiled binaries for Windows. See GH #173.
   - Update C and Java implementations to latest versions [GH #182 by @fonica]
   - Bump default cost to 12 [GH #181 by @bdewater]
+  - Remove explicit support for Rubies 1.8 and 1.9

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ re-hash those passwords. This vulnerability only affected the JRuby gem.
 The bcrypt gem is available on the following Ruby platforms:
 
 * JRuby
-* RubyInstaller 1.8 – 2.5 builds on Windows with the DevKit
-* Any 1.8 – 2.5 Ruby on a BSD/OS X/Linux system with a compiler
+* RubyInstaller 2.0 – 2.5 builds on Windows with the DevKit
+* Any 2.0 – 2.5 Ruby on a BSD/OS X/Linux system with a compiler
 
 ## How to use `bcrypt()` in your Rails application
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,6 @@ build: off
 clone_depth: 1
 
 init:
-  # Install Ruby 1.8.7
-  - if %RUBY_VERSION%==187 (
-      appveyor DownloadFile https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-1.8.7-p374.exe -FileName C:\ruby_187.exe &
-      C:\ruby_187.exe /verysilent /dir=C:\Ruby%RUBY_VERSION%
-    )
-
   # Install Ruby head
   - if %RUBY_VERSION%==head (
       appveyor DownloadFile https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-x86.exe -FileName C:\head_x86.exe &
@@ -21,17 +15,6 @@ init:
 
   # Add Ruby to the path
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
-
-  # Install DevKit 4.5.2 for Ruby 1.8.7
-  - if %RUBY_VERSION%==187 (
-      mkdir C:\DevKit452 &
-      appveyor DownloadFile https://dl.bintray.com/oneclick/rubyinstaller/defunct/DevKit-tdm-32-4.5.2-20110712-1620-sfx.exe -FileName C:\DevKit452\devkit_452.exe &
-      cd C:\DevKit452 &
-      7z x devkit_452.exe &
-      ruby dk.rb init &
-      ruby dk.rb install &
-      cd C:\projects\bcrypt-ruby
-    )
 
 environment:
   matrix:
@@ -49,14 +32,8 @@ environment:
     - RUBY_VERSION: "21-x64"
     - RUBY_VERSION: "200"
     - RUBY_VERSION: "200-x64"
-    - RUBY_VERSION: "193"
-    - RUBY_VERSION: "187"
 
 install:
-  - if %RUBY_VERSION%==187 (
-      gem update --system 2.0.17 &
-      C:\DevKit452\devkitvars.bat
-    )
   - if %RUBY_VERSION%==head     ( gem install bundler )
   - if %RUBY_VERSION%==head-x64 ( gem install bundler )
   - bundle install


### PR DESCRIPTION
As I've repeatedly threatened, I would keep supporting 1.8 and 1.9 until it became too difficult to do so.

Well, that time has come.  I've sunk too many hours into these at this point, and the 4.0 release we're heading towards is a good time to drop explicit support.

They're still _implicitly_ supported in the sense that there's not necessarily anything stopping a user from figuring out how to get them up and running (all of the difficulty is environmental, not bcrypt-ruby's code — compilers and OpenSSLs and CI and installing the Rubies themselves), but I'm not going to let 1.8 and 1.9 test failures be blocking anymore.