### PR TITLE
No rdoc or ri on Appveyor to speed it up

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,11 +34,12 @@ environment:
     - RUBY_VERSION: "200-x64"
 
 install:
+  - ps: "Set-Content -Value 'gem: --no-ri --no-rdoc ' -Path C:\\ProgramData\\gemrc"
   - if %RUBY_VERSION%==head     ( gem install bundler )
   - if %RUBY_VERSION%==head-x64 ( gem install bundler )
   - bundle install
 
-before_test:
+before_build:
   - ruby -v
   - gem -v
 


### PR DESCRIPTION
Before this change, full AppVeyor builds took about 25 minutes pretty consistently.  This brought the current build down to 17 minutes.  Let's hope that sticks!  Regardless, it's harmless even if it doesn't do anything super beneficial.