### PR TITLE
Define SKIP_GNU token when building extension (Fixes FreeBSD >= 12)

### DIFF
--- a/ext/mri/extconf.rb
+++ b/ext/mri/extconf.rb
@@ -16,6 +16,7 @@ else
   # This is `bcrypt_ext` (our extension) + CRYPT_OBJS from that Makefile.
   $objs = %w(bcrypt_ext.o crypt_blowfish.o x86.o crypt_gensalt.o wrapper.o)
 
+  $defs << "-D__SKIP_GNU"
   dir_config("bcrypt_ext")
   create_makefile("bcrypt_ext")
 end


### PR DESCRIPTION
Defining the `SKIP_GNU` token as a compile flag forces the build of `crypt_blowfish` not to attempt redefinition of `crypt` and `crypt_r` which possibly conflict with the system libc depending on their function definition. This allows `bcrypt-ruby` to build again on FreeBSD >= 12.0.

I spent a bunch of time debugging the real reason for why this occurred:

The fine FreeBSD folk just patched out the conflicting function definitions from the vendored C source.

Solardiz suggested that [bcrypt-ruby was interacting with `crypt_blowfish` incorrectly](https://github.com/codahale/bcrypt-ruby/pull/166#issuecomment-446703448), which is entirely possible (I'll humbly defer to Solar Designer here) but I didn't see how/why during my investigation.

Compiling `bcrypt_blowfish` independently works fine on FreeBSD 12. It only fails when linked against anything that's included `unistd.h`.

`bcrypt-ruby` doesn't use `crypt` or `crypt_r` so I think we're safe defining this token and building without those function definitions. The only downside I see is we're now dependent on this token which might be internal only. I don't see it disappearing so I suspect the risk is minimal.