### PR TITLE
Avoid open-ended dependency warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ DEPENDENCIES
   bcrypt!
   rake-compiler (~> 0.9.2)
   rdoc (~> 3.12)
-  rspec (>= 3)
+  rspec (~> 3)
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/bcrypt.gemspec
+++ b/bcrypt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_development_dependency 'rake-compiler', '~> 0.9.2'
-  s.add_development_dependency 'rspec', '>= 3'
+  s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rdoc', '~> 3.12'
 
   s.rdoc_options += ['--title', 'bcrypt-ruby', '--line-numbers', '--inline-source', '--main', 'README.md']


### PR DESCRIPTION
This PR changes a version specifier in the gemspec to **avoid warning output** when building the gem.

This is a trivial dusting change, not a blocker for anything.