### PR TITLE
CI: use Bundler < 2 in Appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,8 +35,8 @@ environment:
 
 install:
   - ps: "Set-Content -Value 'gem: --no-ri --no-rdoc ' -Path C:\\ProgramData\\gemrc"
-  - if %RUBY_VERSION%==head     ( gem install bundler )
-  - if %RUBY_VERSION%==head-x64 ( gem install bundler )
+  - if %RUBY_VERSION%==head     ( gem install bundler -v'< 2' )
+  - if %RUBY_VERSION%==head-x64 ( gem install bundler -v'< 2' )
   - bundle install
 
 before_build:


### PR DESCRIPTION
This PR tries to make all Appveyor builds pass by adding `-v"< 2"` to their Bundler installs.

A hopeful experiment.

**Update:** my mistake, https://ci.appveyor.com/project/TJSchuck35975/bcrypt-ruby is the project linked in the README's Appveyor badge. Not currently connected to the CI webhooks. Should the badge be kept around?