### PR TITLE
Removing the dev dep on RDoc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,27 +6,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    json (1.8.6)
-    json (1.8.6-java)
-    rake (10.4.2)
-    rake-compiler (0.9.5)
+    diff-lcs (1.3)
+    rake (12.3.2)
+    rake-compiler (0.9.9)
       rake
-    rdoc (3.12.2)
-      json (~> 1.4)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
 
 PLATFORMS
   java
@@ -35,7 +31,6 @@ PLATFORMS
 DEPENDENCIES
   bcrypt!
   rake-compiler (~> 0.9.2)
-  rdoc (~> 3.12)
   rspec (>= 3)
 
 BUNDLED WITH

--- a/bcrypt.gemspec
+++ b/bcrypt.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake-compiler', '~> 0.9.2'
   s.add_development_dependency 'rspec', '>= 3'
-  s.add_development_dependency 'rdoc', '~> 3.12'
 
   s.rdoc_options += ['--title', 'bcrypt-ruby', '--line-numbers', '--inline-source', '--main', 'README.md']
   s.extra_rdoc_files += ['README.md', 'COPYING', 'CHANGELOG', *Dir['lib/**/*.rb']]


### PR DESCRIPTION
RDoc depends on JSON 1.8.6 and I can't seem to get that working on
JRuby.  Working around it for now by just removing the dependency.