### PR TITLE
Only override $objs value when building on windows.

### DIFF
--- a/ext/mri/extconf.rb
+++ b/ext/mri/extconf.rb
@@ -12,9 +12,11 @@ if RUBY_PLATFORM == "java"
 else
   require "mkmf"
 
-  # From Openwall's crypt_blowfish Makefile.
-  # This is `bcrypt_ext` (our extension) + CRYPT_OBJS from that Makefile.
-  $objs = %w(bcrypt_ext.o crypt_blowfish.o x86.o crypt_gensalt.o wrapper.o)
+  if RUBY_PLATFORM =~ /cygwin|mswin|mingw|bccwin|wince|emx/
+    # From Openwall's crypt_blowfish Makefile.
+    # This is `bcrypt_ext` (our extension) + CRYPT_OBJS from that Makefile.
+    $objs = %w(bcrypt_ext.o crypt_blowfish.o x86.o crypt_gensalt.o wrapper.o)
+  end
 
   $defs << "-D__SKIP_GNU"
   dir_config("bcrypt_ext")


### PR DESCRIPTION
This fixes #201 

By attempting to include `x86.S` from Openwall crypt other hardware
architectures are attempting to use a source file that does not apply.
In theory this could be extended to ensure ARM versions of Windows
will also skip this source, however the user base that targets seems low
enough to just allow all Windows builds to attempt inclusion.

Test runs on `Windows 10 x46/MacOS 10.14.5/Raspian` all pass compile install and specs.