### PR TITLE
Start calibration from the minimum cost supported by the algorithm

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -92,3 +92,4 @@
   - Update C and Java implementations to latest versions [GH #182 by @fonica]
   - Bump default cost to 12 [GH #181 by @bdewater]
   - Remove explicit support for Rubies 1.8 and 1.9
+  - Start calibration from the minimum cost supported by the algorithm [GH #206 by @sergey-alekseev]

--- a/lib/bcrypt/engine.rb
+++ b/lib/bcrypt/engine.rb
@@ -5,6 +5,8 @@ module BCrypt
     DEFAULT_COST    = 12
     # The minimum cost supported by the algorithm.
     MIN_COST        = 4
+    # The maximum cost supported by the algorithm.
+    MAX_COST = 31
     # Maximum possible size of bcrypt() salts.
     MAX_SALT_LENGTH = 16
 
@@ -99,7 +101,7 @@ module BCrypt
     #   # should take less than 1000ms
     #   BCrypt::Password.create("woo", :cost => 12)
     def self.calibrate(upper_time_limit_in_ms)
-      40.times do |i|
+      (BCrypt::Engine::MIN_COST..BCrypt::Engine::MAX_COST-1).each do |i|
         start_time = Time.now
         Password.create("testing testing", :cost => i+1)
         end_time = Time.now - start_time

--- a/lib/bcrypt/password.rb
+++ b/lib/bcrypt/password.rb
@@ -42,7 +42,7 @@ module BCrypt
       #   @password = BCrypt::Password.create("my secret", :cost => 13)
       def create(secret, options = {})
         cost = options[:cost] || BCrypt::Engine.cost
-        raise ArgumentError if cost > 31
+        raise ArgumentError if cost > BCrypt::Engine::MAX_COST
         Password.new(BCrypt::Engine.hash_secret(secret, BCrypt::Engine.generate_salt(cost)))
       end
 

--- a/spec/bcrypt/engine_spec.rb
+++ b/spec/bcrypt/engine_spec.rb
@@ -1,5 +1,15 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "spec_helper"))
 
+describe 'BCrypt::Engine' do
+  describe '.calibrate(upper_time_limit_in_ms)' do
+    context 'a tiny upper time limit provided' do
+      it 'returns a minimum cost supported by the algorithm' do
+        expect(BCrypt::Engine.calibrate(0.001)).to eq(4)
+      end
+    end
+  end
+end
+
 describe "The BCrypt engine" do
   specify "should calculate the optimal cost factor to fit in a specific time" do
     first = BCrypt::Engine.calibrate(100)


### PR DESCRIPTION
Earlier `BCrypt::Engine.calibrate(0.001)` would return 0 which isn't a valid cost.