### PR TITLE
Fix failing compilation on non-i386 platforms

### DIFF
--- a/ext/mri/x86.S
+++ b/ext/mri/x86.S
@@ -196,8 +196,8 @@ BF_die:
 	hlt
 	jmp BF_die
 
-#endif
-
 #if defined(__ELF__) && defined(__linux__)
 .section .note.GNU-stack,"",@progbits
+#endif
+
 #endif


### PR DESCRIPTION
Non-i386 platforms (e.g. ARM) fail to compile the C-extension because
the .section declaration at the bottom of the x86.S file is not included
in the wrapping `#ifdef __i386__`.

This causes the assembler error:
```
  x86.S:202: Error: junk at end of line, first unrecognized character is `,'
```
because the `@progbits` constant is empty as the object file contains no
data.

This fixes #201 and fixes #204