### PR TITLE
fix issue #201 compilation on non-i386 platforms and #204 as well.

### DIFF
--- a/ext/mri/crypt_blowfish.c
+++ b/ext/mri/crypt_blowfish.c
@@ -517,7 +517,7 @@ static void BF_swap(BF_word *x, int count)
 	R = L; \
 	L = tmp4 ^ data.ctx.P[BF_N + 1];
 
-#if BF_ASM
+#if BF_ASM == 1
 #define BF_body() \
 	_BF_body_r(&data.ctx);
 #else
@@ -650,7 +650,7 @@ static char *BF_crypt(const char *key, const char *setting,
 	char *output, int size,
 	BF_word min)
 {
-#if BF_ASM
+#if BF_ASM == 1
 	extern void _BF_body_r(BF_ctx *ctx);
 #endif
 	struct {

--- a/ext/mri/crypt_blowfish.c
+++ b/ext/mri/crypt_blowfish.c
@@ -361,7 +361,7 @@ static BF_ctx BF_init_state = {
 	}
 };
 
-static unsigned char BF_itoa64[64 + 1] =
+static const unsigned char BF_itoa64[64 + 1] =
 	"./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
 static unsigned char BF_atoi64[0x60] = {
@@ -387,9 +387,8 @@ static int BF_decode(BF_word *dst, const char *src, int size)
 	unsigned char *dptr = (unsigned char *)dst;
 	unsigned char *end = dptr + size;
 	const unsigned char *sptr = (const unsigned char *)src;
-	unsigned int tmp, c1, c2, c3, c4;
-
 	do {
+		unsigned int tmp, c1, c2, c3, c4;
 		BF_safe_atoi64(c1, *sptr++);
 		BF_safe_atoi64(c2, *sptr++);
 		*dptr++ = (c1 << 2) | ((c2 & 0x30) >> 4);
@@ -402,7 +401,6 @@ static int BF_decode(BF_word *dst, const char *src, int size)
 		BF_safe_atoi64(c4, *sptr++);
 		*dptr++ = ((c3 & 0x03) << 6) | c4;
 	} while (dptr < end);
-
 	return 0;
 }
 
@@ -411,9 +409,8 @@ static void BF_encode(char *dst, const BF_word *src, int size)
 	const unsigned char *sptr = (const unsigned char *)src;
 	const unsigned char *end = sptr + size;
 	unsigned char *dptr = (unsigned char *)dst;
-	unsigned int c1, c2;
-
 	do {
+		unsigned int c1, c2;
 		c1 = *sptr++;
 		*dptr++ = BF_itoa64[c1 >> 2];
 		c1 = (c1 & 0x03) << 4;
@@ -442,10 +439,9 @@ static void BF_swap(BF_word *x, int count)
 {
 	static int endianness_check = 1;
 	char *is_little_endian = (char *)&endianness_check;
-	BF_word tmp;
-
 	if (*is_little_endian)
 	do {
+		BF_word tmp;
 		tmp = *x;
 		tmp = (tmp << 16) | (tmp >> 16);
 		*x++ = ((tmp & 0x00FF00FF) << 8) | ((tmp >> 8) & 0x00FF00FF);

--- a/ext/mri/crypt_gensalt.c
+++ b/ext/mri/crypt_gensalt.c
@@ -28,7 +28,7 @@
 /* Just to make sure the prototypes match the actual definitions */
 #include "crypt_gensalt.h"
 
-unsigned char _crypt_itoa64[64 + 1] =
+const unsigned char _crypt_itoa64[64 + 1] =
 	"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 char *_crypt_gensalt_traditional_rn(const char *prefix, unsigned long count,

--- a/ext/mri/crypt_gensalt.h
+++ b/ext/mri/crypt_gensalt.h
@@ -17,7 +17,7 @@
 #ifndef _CRYPT_GENSALT_H
 #define _CRYPT_GENSALT_H
 
-extern unsigned char _crypt_itoa64[];
+extern const unsigned char _crypt_itoa64[];
 extern char *_crypt_gensalt_traditional_rn(const char *prefix,
 	unsigned long count,
 	const char *input, int size, char *output, int output_size);

--- a/ext/mri/x86.S
+++ b/ext/mri/x86.S
@@ -198,6 +198,8 @@ BF_die:
 
 #endif
 
+#ifdef __i386__
 #if defined(__ELF__) && defined(__linux__)
 .section .note.GNU-stack,"",@progbits
+#endif
 #endif


### PR DESCRIPTION
to fix the root-cause, simply merge  -at least- the .S file changes. 
(See github notice: "Able to merge. These branches can be automatically merged.")
How it fix #210 : In case if we add #ifdef around the problematic lines the compilation error will be fixed. The x86 related implementation already skiped by the original implementation of the .c file, so asm code is basically dead-code. The stack related section line is not needed, which cause the compiler error.
How it fix #204: Obviously possible to change Makefile, but more easier to use the same define at the end of asm as the begining of the .S file. It is more consistent, simpler. There is another pull reqest to resolve 204, but there is some CI error relating to that solution actually.
The .c file modification is optional. I was going on direction to add multiple targets, here we have no important changes. 
It is tested on : Ubuntu 16.04.2 LTS (GNU/Linux 4.14.140-bpi-r2-main armv7l) BananaPI R2 router.