### PR TITLE
Fix strdup segfault

### DIFF
--- a/ext/mri/wrapper.c
+++ b/ext/mri/wrapper.c
@@ -17,6 +17,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Redefine strdup to ruby_strdup in case string.h doesn't export it. */
+#include <ruby/util.h>
+
 #include <errno.h>
 #ifndef __set_errno
 #define __set_errno(val) errno = (val)


### PR DESCRIPTION
Same issue as https://github.com/sparklemotion/nokogiri/pull/1517.

`strdup` [is](https://bitbucket.org/einsteintoolkit/tickets/issues/1816) [wild](https://stackoverflow.com/questions/8359966/strdup-returning-address-out-of-bounds).

This fix pulls in ruby/util.h to redefine strdup as ruby_strdup, a portable implementation that sidesteps POSIX/ISO/ANSI confusion.

(Can reproduce this by building with `-std=iso9899:1999`. We were inheriting this from Ruby CFLAGS.)