### PR TITLE
Update to more compatible syntax & protect stack

### DIFF
--- a/ext/mri/x86.S
+++ b/ext/mri/x86.S
@@ -198,8 +198,6 @@ BF_die:
 
 #endif
 
-#ifdef __i386__
 #if defined(__ELF__) && defined(__linux__)
-.section .note.GNU-stack,"",@progbits
-#endif
+.section .note.GNU-stack,"",%progbits
 #endif


### PR DESCRIPTION
By attempting to include `x86.S` from Openwall crypt other hardware
architectures are attempting to use a source file that does not apply.

Update the stack protection to use a more compatible syntax and allow for inclusion of the assembly file to all compilers.