### PR TITLE
Fix v3.1.13 changelog entry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,11 @@
 [DRAFT] 4.0.0 MMM DD YYYY
+  - Start calibration from the minimum cost supported by the algorithm [GH #206 by @sergey-alekseev]
 
 3.1.13 May 31 2019
   - No longer include compiled binaries for Windows. See GH #173.
   - Update C and Java implementations to latest versions [GH #182 by @fonica]
   - Bump default cost to 12 [GH #181 by @bdewater]
   - Remove explicit support for Rubies 1.8 and 1.9
-  - Start calibration from the minimum cost supported by the algorithm [GH #206 by @sergey-alekseev]
-  - Remove explicit support for Rubies 1.8 and 1.9 [GH #185 by @tjschuck]
   - Define SKIP_GNU token when building extension (Fixes FreeBSD >= 12) [GH #189 by @adam12]
 
 3.1.12 May 16 2018


### PR DESCRIPTION
- move a not released changelog entry out of 3.1.13
- remove a duplicated line
- add a newline to the end of file

Fixes #214. Closes #211.

[ci skip]