### PR TITLE
Ensure valid_hash? returns a Boolean

### DIFF
--- a/lib/bcrypt/password.rb
+++ b/lib/bcrypt/password.rb
@@ -47,7 +47,7 @@ module BCrypt
       end
 
       def valid_hash?(h)
-        h =~ /^\$[0-9a-z]{2}\$[0-9]{2}\$[A-Za-z0-9\.\/]{53}$/
+        /^\$[0-9a-z]{2}\$[0-9]{2}\$[A-Za-z0-9\.\/]{53}$/ === h
       end
     end
 

--- a/spec/bcrypt/password_spec.rb
+++ b/spec/bcrypt/password_spec.rb
@@ -116,9 +116,9 @@ end
 
 describe "Validating a password hash" do
   specify "should not accept an invalid password" do
-    expect(BCrypt::Password.valid_hash?("i_am_so_not_valid")).to be_falsey
+    expect(BCrypt::Password.valid_hash?("i_am_so_not_valid")).to be(false)
   end
   specify "should accept a valid password" do
-    expect(BCrypt::Password.valid_hash?(BCrypt::Password.create "i_am_so_valid")).to be_truthy
+    expect(BCrypt::Password.valid_hash?(BCrypt::Password.create "i_am_so_valid")).to be(true)
   end
 end


### PR DESCRIPTION
I noticed that `valid_hash?` returns either `nil` or `0`.
Since the [docs](https://www.rubydoc.info/github/codahale/bcrypt-ruby/BCrypt%2FPassword.valid_hash%3F) list valid_hash? as returning a Boolean, I thought this might be a bug.