### PR TITLE
Fix building on FreeBSD 12

### DIFF
--- a/ext/mri/wrapper.c
+++ b/ext/mri/wrapper.c
@@ -179,6 +179,7 @@ char *crypt_ra(const char *key, const char *setting,
 	return _crypt_blowfish_rn(key, setting, (char *)*data, *size);
 }
 
+#ifndef __SKIP_GNU
 char *crypt_r(const char *key, const char *setting, void *data)
 {
 	return _crypt_retval_magic(
@@ -194,6 +195,7 @@ char *crypt(const char *key, const char *setting)
 		crypt_rn(key, setting, output, sizeof(output)),
 		setting, output, sizeof(output));
 }
+#endif
 
 #define __crypt_gensalt_rn crypt_gensalt_rn
 #define __crypt_gensalt_ra crypt_gensalt_ra


### PR DESCRIPTION
Based on a similar previous commit in ow-crypt.h, skip (re)defining crypt_r function signatures when they already exist in unistd.h

Not sure if this is completely the correct fix, but seems to work with FreeBSD and passes specs. Just unsure if it's then broken other platforms... 

Without the fix, it has a similar error to building 3.1.12 on FreeBSD 12:

```
compiling ../../../../ext/mri/wrapper.c
../../../../ext/mri/wrapper.c:182:7: error: conflicting types for 'crypt_r'
char *crypt_r(const char *key, const char *setting, void *data)
      ^
/usr/include/unistd.h:499:7: note: previous declaration is here
char    *crypt_r(const char *, const char *, struct crypt_data *);
         ^
1 error generated.
```

FreeBSD 12.1
Ruby 2.6.6
FreeBSD clang version 8.0.1 (tags/RELEASE_801/final 366581) (based on LLVM 8.0.1)