### PR TITLE
Fix crypt_r definition

### DIFF
--- a/ext/mri/wrapper.c
+++ b/ext/mri/wrapper.c
@@ -179,7 +179,7 @@ char *crypt_ra(const char *key, const char *setting,
 	return _crypt_blowfish_rn(key, setting, (char *)*data, *size);
 }
 
-char *crypt_r(const char *key, const char *setting, void *data)
+char *crypt_r(const char *key, const char *setting, struct crypt_data *data)
 {
 	return _crypt_retval_magic(
 		crypt_rn(key, setting, data, CRYPT_OUTPUT_SIZE),


### PR DESCRIPTION
Its last argument should be of type `struct crypt_data *`, not `void *` according to https://linux.die.net/man/3/crypt_r

This fixes #233 and seems to be a better approach than #232. 