### PR TITLE
Additional Changelog comment for Fedora/Ubuntu

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,7 +16,7 @@
 
 3.1.12 May 16 2018
   - Add support for Ruby 2.3, 2.4, and 2.5 in compiled Windows binaries
-  - Fix compatibility with libxcrypt [GH #164 by @besser82]
+  - Fix compatibility with libxcrypt - Fixes hash errors in Fedora 28 and Ubuntu 20 [GH #164 by @besser82]
 
 3.1.11 Mar 06 2016
   - Add support for Ruby 2.2 in compiled Windows binaries


### PR DESCRIPTION
Version 3.1.12 fixes a compatibility issue with libxcrypt (PR #164 ).  
What it doesn't say explicitly is that this compatibility issue affects Ubuntu and Fedora updates.  It took me longer than I'd like to admit to figure out why password authentication was broken.  Skimming the changelog didn't seem to offer any specific reasons, and I figured it was somewhere else in the stack.

This PR simply updates the changelog that this version fixes issues with Fedora and Ubuntu versions.

I know it's a miniscule contribution, but if I can save someone else the few hours it took me to track down the odd issue, it will have been worth it.

