### PR TITLE
Ignore Gemfile.lock in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 *.jar
 .DS_Store
 .rbenv-gemsets
+Gemfile.lock


### PR DESCRIPTION
This repository does not contain `Gemfile.lock`.  But current `.gitignore` does not contain it too, so `bundle install` makes `Untracked files`