### PR TITLE
BCrypt::Password comparison edge-case / bug

### DIFF
--- a/lib/bcrypt/password.rb
+++ b/lib/bcrypt/password.rb
@@ -61,9 +61,14 @@ module BCrypt
       end
     end
 
-    # Compares a potential secret against the hash. Returns true if the secret is the original secret, false otherwise.
+    # Compares a potential secret against the hash. Returns true if the secret
+    # is the original secret, false otherwise.
     def ==(secret)
-      super(BCrypt::Engine.hash_secret(secret, @salt))
+      if valid_hash?(secret)
+        super(secret)
+      else
+        super(BCrypt::Engine.hash_secret(secret, @salt))
+      end
     end
     alias_method :is_password?, :==
 

--- a/spec/bcrypt/password_spec.rb
+++ b/spec/bcrypt/password_spec.rb
@@ -103,6 +103,19 @@ describe "Comparing a hashed password with a secret" do
   specify "should compare unsuccessfully to anything besides original secret" do
     expect((@password == "@secret")).to be(false)
   end
+
+  # Edge case discovered during Sorcery rework
+  specify "should be able to compare against itself" do
+    # original_password can be any valid password, Faker::Internet.password was
+    # used to generate this particular example.
+    original_password = '62SeEjVz'
+    random_cost = rand(BCrypt::Engine::MIN_COST..BCrypt::Engine::DEFAULT_COST)
+    digest = BCrypt::Password.create(original_password, cost: random_cost).to_s
+    bcrypt = BCrypt::Password.new(digest)
+    hashed_password = BCrypt::Engine.hash_secret(original_password, bcrypt.salt)
+
+    expect(bcrypt == hashed_password).to be(true)
+  end
 end
 
 describe "Validating a generated salt" do


### PR DESCRIPTION
While working on the Sorcery rework, I found an edge case/bug where taking a valid BCrypt::Password instance and trying to compare it using `==` against an identical string causes it to return false.

This can be solved by checking if the secret being compared by `==` is a valid BCrypt hash, and comparing it directly in those situations.

This solution will need to be vetted that it doesn't cause any vulnerabilities.