### PR TITLE
Document BCrypt::Password#== edge case/gotcha

### DIFF
--- a/lib/bcrypt/password.rb
+++ b/lib/bcrypt/password.rb
@@ -62,6 +62,15 @@ module BCrypt
     end
 
     # Compares a potential secret against the hash. Returns true if the secret is the original secret, false otherwise.
+    #
+    # Comparison edge case/gotcha:
+    #
+    #    secret = "my secret"
+    #    @password = BCrypt::Password.create(secret)
+    #
+    #    @password == secret              # => True
+    #    @password == @password.to_s      # => False
+    #    @password.to_s == @password.to_s # => True
     def ==(secret)
       super(BCrypt::Engine.hash_secret(secret, @salt))
     end

--- a/lib/bcrypt/password.rb
+++ b/lib/bcrypt/password.rb
@@ -69,7 +69,9 @@ module BCrypt
     #    @password = BCrypt::Password.create(secret)
     #
     #    @password == secret              # => True
+    #    @password == @password           # => False
     #    @password == @password.to_s      # => False
+    #    @password.to_s == @password      # => True
     #    @password.to_s == @password.to_s # => True
     def ==(secret)
       super(BCrypt::Engine.hash_secret(secret, @salt))


### PR DESCRIPTION
Documents the edge case mentioned on #245 to alleviate downstream developer confusion.

@tjschuck This will probably suffice without introducing any code changes.